### PR TITLE
Refactor common logic between Arg(s) into own type

### DIFF
--- a/arg.go
+++ b/arg.go
@@ -126,8 +126,10 @@ type argCore[T any] struct {
 func (a *argCore[T]) updateValue(s ...string) error {
 	v := a.Variable()
 
-	if a.parsed && a.supplied {
-		return nil
+	if a.parsed {
+		if a.supplied {
+			return nil
+		}
 	}
 
 	var input []string

--- a/arg.go
+++ b/arg.go
@@ -115,7 +115,7 @@ type argCore[T any] struct {
 	repeatable, supplied, parsed bool
 }
 
-func (a *argCore[T]) updateValue(s ...string) (err error) {
+func (a *argCore[T]) updateValue(s ...string) error {
 	v := a.Variable()
 
 	if a.parsed && a.supplied {
@@ -134,7 +134,13 @@ func (a *argCore[T]) updateValue(s ...string) (err error) {
 		}
 	}
 
-	return v.Update(input...)
+	if err := v.Update(input...); err != nil {
+		return err
+	}
+
+	a.parsed = true
+
+	return nil
 }
 
 func (a *argCore[T]) updateMetadata(opts ...Option) {

--- a/arg.go
+++ b/arg.go
@@ -100,6 +100,13 @@ func newArgCore[T any](v *T, parser parse.Parser[T], options ...Option) *argCore
 	}
 }
 
+func newArgCoreUsing[T any](v Variable[T], options ...Option) *argCore[T] {
+	return &argCore[T]{
+		v:  v,
+		md: NewMetadata(options...),
+	}
+}
+
 // argCore contains the underlying Variable[T] and *Metadata for an Arg.
 type argCore[T any] struct {
 	v  Variable[T]

--- a/arg.go
+++ b/arg.go
@@ -9,13 +9,16 @@ import (
 
 //go:generate mockgen -destination=mocks.go -copyright_file=internal/mock_header.txt -package=clap github.com/runaek/clap FileReader,FileWriter,FileInfo,PositionalDeriver,KeyValueDeriver,FlagDeriver
 
-// Arg is the shared behaviour of all command-line input types (FlagType, KeyValueType and PositionType). It essentially
-// exposes an API similar to the behaviour seen in the standard 'flags' package, extending support to key-value and
-// positional arguments.
+// Arg is the shared behaviour of all command-line input types (FlagType,
+// KeyValueType and PositionType). It essentially exposes an API similar to the
+// behaviour seen in the standard 'flags' package, extending support to
+// key-value and positional arguments.
 //
-// Metadata is attached to each Arg giving each arg some mutable properties which can be managed via Option(s).
+// Metadata is attached to each Arg giving each arg some mutable properties
+// which can be managed via Option(s).
 //
-// Each Arg has its own go-argumentVariable which it is responsible for updating:
+// Each Arg has its own go-argumentVariable which it is responsible for
+// updating:
 //
 //  import (
 // 		. "github.com/runaek/clap"
@@ -25,8 +28,10 @@ import (
 //	var (
 //		strVal string
 //		numVal int
-//		myArg = NewKeyValue[string](&strVal, "arg1", parse.String, <options>...) // arg1=Test123 => strVal=Test123
-//		numFlag = NewFlag[int](&numVal, "amount", parse.Int, <options>...)       // --amount=123 => numVal=123
+// 		// arg1=Test123 => strVal=Test123
+//		myArg = NewKeyValue[string](&strVal, "arg1", parse.String, <options>...)
+//		// --amount=123 => numVal=123
+//		numFlag = NewFlag[int](&numVal, "amount", parse.Int, <options>...)
 //
 //		parser = clap.New("program-Id").
 //				Add(myArg, numFlag).
@@ -46,10 +51,12 @@ type Arg interface {
 
 	Updater
 
-	// Name returns the key/identifier of the Arg, this should be unique for each Type.
+	// Name returns the key/identifier of the Arg, this should be unique for
+	// each Type
 	Name() string
 
-	// Type indicates the type of command-line argument the Arg is, returns one of:
+	// Type indicates the type of command-line argument the Arg is, returns one
+	// of:
 	//
 	// 	> FlagType;
 	//
@@ -60,7 +67,8 @@ type Arg interface {
 	//	> PipeType;
 	Type() Type
 
-	// Shorthand is the single character alias/identifier for the Arg, if applicable
+	// Shorthand is the single character alias/identifier for the Arg, if
+	// applicable
 	//
 	// Can be updated via the WithAlias Option
 	Shorthand() string
@@ -199,9 +207,11 @@ func Generalize[T any](typed ...TypedArg[T]) []Arg {
 	return out
 }
 
-// TypedArg is the generic interface that is satisfied by all Arg implementations.
+// TypedArg is the generic interface that is satisfied by all Arg
+// implementations.
 //
-// This is a convenience interface that provides access to the underlying generic Variable.
+// This is a convenience interface that provides access to the underlying
+// generic Variable.
 type TypedArg[T any] interface {
 	Arg
 	// Variable returns the underlying Variable for the Arg
@@ -214,12 +224,12 @@ type Identifier interface {
 	argName() argName
 }
 
-// NameOf is a helper function for getting the name of an Arg from an Identifier.
+// NameOf returns the name of an Arg from an Identifier.
 func NameOf(id Identifier) string {
 	return id.argName().Name()
 }
 
-// TypeOf is a helper function for getting the type of Arg from an Identifier.
+// TypeOf returns the type of Arg from an Identifier.
 func TypeOf(id Identifier) Type {
 	return id.argName().Type()
 }
@@ -228,7 +238,7 @@ const (
 	ErrInvalidType Error = "invalid type"
 )
 
-// ValueOf is a helper function for retrieving the value of an Arg.
+// ValueOf returns the typed value of an Arg.
 func ValueOf[T any](arg Arg) (T, error) {
 	var zero T
 
@@ -239,7 +249,7 @@ func ValueOf[T any](arg Arg) (T, error) {
 	return zero, fmt.Errorf("%w: unable to read %T value from %T", ErrInvalidType, zero, arg)
 }
 
-// ReferenceTo is a helper function for retrieving a reference to the value for an Arg.
+// ReferenceTo returns a reference to the value for an Arg.
 func ReferenceTo[T any](arg Arg) (*T, error) {
 	if arg == nil {
 		return nil, errors.New("nil reference")
@@ -254,8 +264,9 @@ func ReferenceTo[T any](arg Arg) (*T, error) {
 	return nil, fmt.Errorf("%w: unable to reference variable of type %T from %T", ErrInvalidType, zero, arg)
 }
 
-// Updater is the shared private behaviour shared by all Arg which allows mutable *Metadata fields to be updated
-// and the underlying value/variable of an Arg to be updated.
+// Updater is the shared private behaviour shared by all Arg which allows
+// mutable *Metadata fields to be updated and the underlying value/variable of
+// an Arg to be updated.
 type Updater interface {
 	updateValue(...string) error
 	updateMetadata(...Option)
@@ -269,7 +280,8 @@ func UpdateValue(u Updater, input ...string) error {
 	return u.updateValue(input...)
 }
 
-// UpdateMetadata is the public helper function to update the Metadata of some Arg.
+// UpdateMetadata is the public helper function to update the Metadata of some
+// Arg.
 func UpdateMetadata(u Updater, options ...Option) {
 	u.updateMetadata(options...)
 }
@@ -308,7 +320,8 @@ func (id argName) argName() argName {
 	return id
 }
 
-// ValidateDefaultValue is a helper function for retrieving and attempting to parse the actual typed default value
+// ValidateDefaultValue is a helper function for retrieving and attempting to
+// parse the actual typed default value
 // of an Arg.
 func ValidateDefaultValue[T any](arg TypedArg[T]) (T, error) {
 	var zero T
@@ -337,7 +350,8 @@ func ValidateDefaultValue[T any](arg TypedArg[T]) (T, error) {
 	return val, nil
 }
 
-// Type indicates the 'type' of input being processed (either a flag, key-value argument or a positional argument).
+// Type indicates the 'type' of input being processed (either a flag, key-value
+// argument or a positional argument).
 type Type int
 
 func (t Type) String() string {

--- a/derive.go
+++ b/derive.go
@@ -14,12 +14,14 @@ func notFound(t Type, deriver string) error {
 	return fmt.Errorf("%w (%s): %s", ErrDeriverNotFound, t, deriver)
 }
 
-// A PositionalDeriver is responsible for constructing a PositionalArg dynamically.
+// A PositionalDeriver is responsible for constructing a PositionalArg
+// dynamically.
 type PositionalDeriver interface {
 	DerivePosition(v any, index int, opts ...Option) (IPositional, error)
 }
 
-// A KeyValueDeriver is responsible for constructing a KeyValueArg dynamically.
+// A KeyValueDeriver is responsible for constructing a KeyValueArg
+// dynamically.
 type KeyValueDeriver interface {
 	DeriveKeyValue(v any, name string, opts ...Option) (IKeyValue, error)
 }
@@ -29,29 +31,31 @@ type FlagDeriver interface {
 	DeriveFlag(v any, name string, opts ...Option) (IFlag, error)
 }
 
-// RegisterPositionalDeriver adds a PositionalDeriver to the program so that it can be detected
-// and used within struct-tags.
+// RegisterPositionalDeriver adds a PositionalDeriver to the program so that it
+// can be detected and used within struct-tags.
 func RegisterPositionalDeriver(name string, d PositionalDeriver) {
 	positionalDerivers[name] = d
 }
 
-// RegisterKeyValueDeriver adds a KeyValueDeriver to the program so that it can be detected
-// and used within struct-tags.
+// RegisterKeyValueDeriver adds a KeyValueDeriver to the program so that it can
+// be detected and used within struct-tags.
 func RegisterKeyValueDeriver(name string, d KeyValueDeriver) {
 	keyValueDerivers[name] = d
 }
 
-// RegisterFlagDeriver adds a FlagDeriver to the program so that it can be detected
-// and used within struct-tags.
+// RegisterFlagDeriver adds a FlagDeriver to the program so that it can be
+// detected and used within struct-tags.
 func RegisterFlagDeriver(name string, d FlagDeriver) {
 	flagDerivers[name] = d
 }
 
-// Derive attempts to construct a number of Arg dynamically from some struct-tags.
+// Derive attempts to construct a number of Arg dynamically from some
+// struct-tags.
 //
-// The tags are applied on the fields to be bound to the Arg (i.e. at runtime, the Field will hold
-// the value of the Arg). There are 4 formats for each of the types and all can be prefixed with a
-// '!' which will mark the Arg as required:
+// The tags are applied on the fields to be bound to the Arg (i.e. at runtime,
+// the Field will hold the value of the Arg). There are 4 formats for each of
+// the types and all can be prefixed with a '!' which will mark the Arg as
+// required:
 //
 // 1. KeyValueArg: `cli:"@<name>|<alias>:<deriver>"
 //
@@ -61,16 +65,19 @@ func RegisterFlagDeriver(name string, d FlagDeriver) {
 //
 // 4. PositionalArg(s): `cli:"#<index>...:<deriver>"
 //
-// Where the 'deriver' is the name assigned to the deriver when it was registered (using one of
-// RegisterKeyValueDeriver, RegisterFlagDeriver or RegisterPositionalDeriver).
+// Where the 'deriver' is the name assigned to the deriver when it was
+// registered (using one of RegisterKeyValueDeriver, RegisterFlagDeriver or
+// RegisterPositionalDeriver).
 //
-// Usage strings can be supplied by creating a string field in the struct called <Name>Usage, the
-// same can be done for a default value (i.e. <Name>Default). At runtime, the values held by the
-// variable will be used for the respective usage/default.
+// Usage strings can be supplied by creating a string field in the struct called
+// <Name>Usage, the same can be done for a default value (i.e. <Name>Default).
+// At runtime, the values held by the variable will be used for the respective
+// usage/default.
 //
-// Package `github.com/runaek/clap/pkg/derivers` provides support to a number of the
-// built-in Go types. The program `github.com/runaek/clap/cmd/generate_derivers` is
-// a codegen tool for helping generate FlagDeriver, KeyValueDeriver and PositionalDeriver
+// Package `github.com/runaek/clap/pkg/derivers` provides support to a number of
+// the built-in Go types.
+// The program `github.com/runaek/clap/cmd/generate_derivers` is a codegen tool
+// for helping generate FlagDeriver, KeyValueDeriver and PositionalDeriver
 // implementations using a specified parse.Parse[T].
 //
 //
@@ -109,8 +116,9 @@ func RegisterFlagDeriver(name string, d FlagDeriver) {
 //
 //		// use args
 //	}
-// NOTE: Fields should be defined in the same order you would expect to add them to a Parser manually (i.e. Field
-// referring to the 1st positional argument must come before the Field referring to the 2nd positional argument).
+// NOTE: Fields should be defined in the same order you would expect to add them
+// to a Parser manually (i.e. Field referring to the 1st positional argument
+// must come before the Field referring to the 2nd positional argument).
 func Derive(source any) ([]Arg, error) {
 	return deriveArgs(source)
 }
@@ -143,8 +151,9 @@ var (
 	flagDerivers       = map[string]FlagDeriver{}
 )
 
-// deriveArgs is a helper function for reading and creating Arg implementations using struct-tags and
-// FlagDeriver, KeyValueDeriver and PositionalDeriver implementations that have been registered.
+// deriveArgs is a helper function for reading and creating Arg implementations
+// using struct-tags and FlagDeriver, KeyValueDeriver and PositionalDeriver
+// implementations that have been registered.
 func deriveArgs(src any) ([]Arg, error) {
 	program, err := derive.Parse(src)
 

--- a/error.go
+++ b/error.go
@@ -18,8 +18,8 @@ const (
 
 // Error is a simple indicator for some error that occurs.
 //
-// The value of the error should indicate the 'cause' of the problem and context should be provided by the returning
-// process.
+// The value of the error should indicate the 'cause' of the problem and context
+// should be provided by the returning process.
 type Error string
 
 func (err Error) Error() string {
@@ -66,7 +66,8 @@ func ErrParsing(id Identifier, cause error) *ParseError {
 	}
 }
 
-// ParseError indicates that an error occurred parsing the variable for some argument.
+// ParseError indicates that an error occurred parsing the variable for some
+// argument.
 type ParseError struct {
 	Id    Identifier
 	Cause error

--- a/flag.go
+++ b/flag.go
@@ -9,7 +9,8 @@ import (
 type IFlag interface {
 	Arg
 
-	// IsIndicator returns true if the FlagArg does not require a value (e.g. a bool or C)
+	// IsIndicator returns true if the FlagArg does not require a value (e.g. a
+	// bool or C)
 	IsIndicator() bool
 
 	// HasDefault returns true if the flag has a defined default string value
@@ -18,7 +19,8 @@ type IFlag interface {
 	isFlagArg()
 }
 
-// Help is a constructor for some *FlagArg[bool] (identified by '--help'/'-h') type.
+// Help is a constructor for some *FlagArg[bool] (identified by '--help'/'-h')
+// type.
 func Help(helpRequested *bool, desc string) *FlagArg[bool] {
 	if desc == "" {
 		desc = "Display the help-text for a command or program."
@@ -82,7 +84,8 @@ func FlagUsingVariable[T any](name string, v Variable[T], opts ...Option) *FlagA
 	return f
 }
 
-// FlagsUsingVariable is a constructor for a repeatable FlagArg using a Id and some Variable.
+// FlagsUsingVariable is a constructor for a repeatable FlagArg using an Id and
+// some Variable.
 func FlagsUsingVariable[T any](name string, v Variable[[]T], opts ...Option) *FlagArg[[]T] {
 
 	if md := NewMetadata(opts...); md.Usage() == "" {

--- a/flag.go
+++ b/flag.go
@@ -90,9 +90,12 @@ func FlagsUsingVariable[T any](name string, v Variable[[]T], opts ...Option) *Fl
 		opts = append(opts, WithUsage(fmt.Sprintf("%s - a repeatable %T flag variable.", name, zero)))
 	}
 
+	core := newArgCoreUsing[[]T](v, opts...)
+	core.repeatable = true
+
 	f := &FlagArg[[]T]{
 		Key:     name,
-		argCore: newArgCoreUsing[[]T](v, opts...),
+		argCore: core,
 	}
 
 	f.repeatable = true
@@ -123,16 +126,6 @@ func (f *FlagArg[T]) Name() string {
 
 func (f *FlagArg[T]) Type() Type {
 	return FlagType
-}
-
-// func (f *FlagArg[T]) ValueType() string {
-// 	var zero T
-//
-// 	return strings.TrimPrefix(fmt.Sprintf("%T", zero), "*")
-// }
-
-func (f *FlagArg[T]) Variable() Variable[T] {
-	return f.v
 }
 
 func (f *FlagArg[T]) IsIndicator() bool {

--- a/keyvalue.go
+++ b/keyvalue.go
@@ -22,10 +22,11 @@ func NewKeyValue[T any](variable *T, name string, p parse.Parser[T], opts ...Opt
 	return KeyValueUsingVariable[T](name, v, opts...)
 }
 
-// NewKeyValues is a constructor for a repeatable key-valued arguments from the command-line.
+// NewKeyValues is a constructor for a repeatable key-valued arguments from the
+// command-line.
 //
-// Automatically converts the Func[T] into a Func[[]T] via parse.Slice - use KeyValuesUsingVariable
-// to be able to change this behaviour as required.
+// Automatically converts the Func[T] into a Func[[]T] via parse.Slice - use
+// KeyValuesUsingVariable to be able to change this behaviour as required.
 func NewKeyValues[T any](variables *[]T, name string, p parse.Parser[T], opts ...Option) *KeyValueArg[[]T] {
 	v := NewVariables[T](variables, p)
 
@@ -48,7 +49,8 @@ func KeyValueUsingVariable[T any](name string, v Variable[T], opts ...Option) *K
 	return kv
 }
 
-// KeyValuesUsingVariable allows a repeatable KeyValueArg to be constructed using Variable.
+// KeyValuesUsingVariable allows a repeatable KeyValueArg to be constructed
+// using a Variable.
 func KeyValuesUsingVariable[T any](name string, v Variable[[]T], opts ...Option) *KeyValueArg[[]T] {
 
 	if md := NewMetadata(opts...); md.Usage() == "" {
@@ -74,10 +76,11 @@ func (k Key) argName() argName {
 	return KeyValueType.getIdentifier(string(k))
 }
 
-// A KeyValueArg represents a key=value argument where the key is a string and the value is a string representation for
-// some type T.
+// A KeyValueArg represents a key=value argument where the key is a string and
+// the value is a string representation for some type T.
 //
-// Should be created by the functions: NewKeyValue, NewKeyValues, KeyValueUsingVariable and KeyValuesUsingVariable.
+// Should be created by the functions: NewKeyValue, NewKeyValues,
+// KeyValueUsingVariable and KeyValuesUsingVariable.
 type KeyValueArg[T any] struct {
 	Key string
 	*argCore[T]

--- a/metadata.go
+++ b/metadata.go
@@ -33,7 +33,8 @@ func AsRequired() Option {
 	}
 }
 
-// withDefaultDisabled is a private Option that is added to every Arg implementation which does not support defaults.
+// withDefaultDisabled is a private Option that is added to every Arg
+// implementation which does not support defaults.
 //
 // Namely, PipeArg and PositionalArg.
 func withDefaultDisabled() Option {

--- a/parser.go
+++ b/parser.go
@@ -910,7 +910,7 @@ func (p *Parser) parse() {
 
 		// if strict-mode: add the error to the final pErr
 		// otherwise, we just need to update the state of the Arg
-		if p.Strict || a.IsRequired() {
+		if !a.IsSupplied() && (p.Strict || a.IsRequired()) {
 			p.pErr = multierror.Append(p.pErr, fmt.Errorf("%w: %s (%s)", ErrMissing, a.Name(), a.Type()))
 		}
 

--- a/parser.go
+++ b/parser.go
@@ -887,9 +887,8 @@ func (p *Parser) parse() {
 	for _, a := range p.Args() {
 		log.Debug("Checking Argument", zap.String("name", a.Name()), zap.Stringer("type", a.Type()), zap.String("default", a.Default()))
 
-		if a.IsParsed() {
+		if a.IsParsed() && a.IsSupplied() {
 			p.updateState(a, ok)
-
 			continue
 		}
 

--- a/parser.go
+++ b/parser.go
@@ -784,6 +784,7 @@ func (p *Parser) scan(input []string) (remaining, consumed []string, err error) 
 // NOTE: assumes that input has already been scanned
 func (p *Parser) parse() {
 	if pipe := p.Pipe(); pipe != nil && pipe.IsSupplied() {
+		log.Info("Parsing Pipe argument.")
 		if err := pipe.updateValue(); err != nil {
 			p.updateState(pipe, err)
 
@@ -815,6 +816,7 @@ func (p *Parser) parse() {
 
 			variadicValues = append(variadicValues, v)
 		} else {
+			log.Debug("Updating positional argument value.", zap.String("arg", pA.Name()), zap.String("value", v))
 			if err := pA.updateValue(v); err != nil {
 				p.updateState(pA, err)
 
@@ -827,8 +829,7 @@ func (p *Parser) parse() {
 
 	if variadicIndex > 0 {
 		variadicPosArg := p.Pos(variadicIndex)
-		log.Debug("Updating variadic positional arguments", zap.Strings("vals", variadicValues))
-
+		log.Debug("Updating variadic positional arguments.", zap.String("arg", variadicPosArg.Name()), zap.Strings("values", variadicValues))
 		if err := variadicPosArg.updateValue(variadicValues...); err != nil {
 			p.updateState(variadicPosArg, err)
 
@@ -848,7 +849,7 @@ func (p *Parser) parse() {
 
 			continue
 		}
-
+		log.Debug("Updating key-value argument.", zap.String("arg", name), zap.Strings("values", vs))
 		if err := kvA.updateValue(vs...); err != nil {
 			// we always want to update the state to track every Arg that fails,
 			// but we only want to add an error if we are running in strict mode

--- a/parser.go
+++ b/parser.go
@@ -562,15 +562,16 @@ var (
 	ok       = errors.New("ok")
 )
 
-// scan some input for argument tokens (i.e. a positional argument, a key-value argument value or a
-// flag argument value).
+// scan some input for argument tokens (i.e. a positional argument, a key-value
+// argument value or a flag argument value).
 //
-// Returns the tokens that were 'consumed' (successful or not), the remaining un-scanned tokens in
-// the input and any errors associated with scanning the 'consumed' tokens
+// Returns the tokens that were 'consumed' (successful or not), the remaining
+// un-scanned tokens in the input and any errors associated with scanning the
+// 'consumed' tokens
 //
-// NOTE: will *not* recursively call itself, it will scan a single token (1 or 2 elements) and
-// return - it is on the caller to make repeated calls to scan to consume the entire input, which
-// is when scan will return finished.
+// NOTE: will *not* recursively call itself, it will scan a single token (1 or
+// 2 elements) and return - it is on the caller to make repeated calls to scan
+// to consume the entire input, which is when scan will return finished.
 func (p *Parser) scan(input []string) (remaining, consumed []string, err error) {
 	if len(input) < 1 {
 		return nil, nil, finished
@@ -593,7 +594,8 @@ func (p *Parser) scan(input []string) (remaining, consumed []string, err error) 
 	if this == "-h" || this == "--help" {
 		return left, consumed, ErrHelp
 	}
-	// detect the Type and argID from 'this' and sanitize (additionally, calculated argValue if possible)
+	// detect the Type and argID from 'this' and sanitize (additionally,
+	// calculated argValue if possible)
 	switch this[0] {
 	case '-':
 		// any '-' prefix indicates 'this' is a FlagType
@@ -606,8 +608,9 @@ func (p *Parser) scan(input []string) (remaining, consumed []string, err error) 
 		fallthrough
 	default:
 		if strings.Contains(this, "=") {
-			// argType will be == FlagType if it was detected in the above block, if it is
-			// still Unrecognised, then it must be a KeyValueType
+			// argType will be == FlagType if it was detected in the above
+			// block, if it is still Unrecognised, then it must be a
+			// KeyValueType
 			if argType == Unrecognised {
 				argType = KeyValueType
 			}
@@ -635,8 +638,9 @@ func (p *Parser) scan(input []string) (remaining, consumed []string, err error) 
 	}
 
 	defer func() {
-		// At this point, we know what each of the argType is, so we can explicitly handle the case here and not have
-		// to repeat it in the below block.
+		// At this point, we know what each of the argType is, so we can
+		// explicitly handle the case here and not have to repeat it in the
+		// below block.
 
 		log.Debug("Scanned tokens",
 			zap.String("arg_id", argID),
@@ -658,8 +662,8 @@ func (p *Parser) scan(input []string) (remaining, consumed []string, err error) 
 
 	switch argType {
 	case PositionType:
-		// for Positional argMap, we only care about this specific position and so do not consume any extra values
-		// from the input
+		// for Positional argMap, we only care about this specific position and
+		// so do not consume any extra values from the input
 		argValue = this
 		argID = fmt.Sprintf("%d", len(p.positionalValues)+1)
 
@@ -672,9 +676,11 @@ func (p *Parser) scan(input []string) (remaining, consumed []string, err error) 
 			return left, consumed, fmt.Errorf("%w: no such Key", ErrUnidentified)
 		}
 	case FlagType:
-		// for FlagArg argMap we need to check if we are dealing with a BOOL flag - if we are, then we don't need to
-		// consume any extra input, otherwise we may need to consume some extra input. We also need to check for
-		// combined shorthands (e.g. -nWXyZ may need to be converted into -n -W -X -y -Z)
+		// for FlagArg argMap we need to check if we are dealing with a BOOL
+		// flag - if we are, then we don't need to consume any extra input,
+		// otherwise we may need to consume some extra input. We also need to
+		// check for combined shorthands (e.g. -nWXyZ may need to be converted
+		// into -n -W -X -y -Z)
 
 		fA := p.Flag(argID)
 
@@ -713,14 +719,17 @@ func (p *Parser) scan(input []string) (remaining, consumed []string, err error) 
 			}
 		}
 
-		// flag was supplied like -k=<value> or --key=<value> => no more input to be consumed
+		// flag was supplied like -k=<value> or --key=<value> => no more input
+		// to be consumed
 		if argValueDetected || fA == nil {
 			break
 		}
 
-		// we don't know the argValue yet, but it may be that the Flag is an indicator and doesn't require a value - if
-		// this is the case, we can go and set some sensible defaults if they do not exist (e.g. false for bool flags).
-		// Otherwise, we know we need to consume (or try to) the next token to get the value for the flag
+		// we don't know the argValue yet, but it may be that the Flag is an
+		// indicator and doesn't require a value - if this is the case, we can
+		// go and set some sensible defaults if they do not exist (e.g. false
+		// for bool flags). Otherwise, we know we need to consume (or try to)
+		// the next token to get the value for the flag
 		if fA.IsIndicator() {
 			log.Debug("Handling INDICATOR flag", zap.String("_t", fmt.Sprintf("%T", fA)))
 
@@ -829,7 +838,8 @@ func (p *Parser) parse() {
 	for name, vs := range p.keyValues {
 		kvA := p.Key(name)
 
-		// no need to log an error since this would have been noticed during the scan
+		// no need to log an error since this would have been noticed during the
+		// scan
 		if kvA == nil {
 			log.Warn("No such key-value argument to parse", zap.String("name", name), zap.Strings("values", vs))
 
@@ -837,8 +847,9 @@ func (p *Parser) parse() {
 		}
 
 		if err := kvA.updateValue(vs...); err != nil {
-			// we always want to update the state to track every Arg that fails, but we only want to add an error if we
-			// are running in strict mode (which prohibits any parser failures) or if the arg is required
+			// we always want to update the state to track every Arg that fails,
+			// but we only want to add an error if we are running in strict mode
+			// (which prohibits any parser failures) or if the arg is required
 			p.updateState(kvA, err)
 			if kvA.IsRequired() || p.Strict {
 				p.pErr = multierror.Append(p.pErr, err)
@@ -849,7 +860,8 @@ func (p *Parser) parse() {
 	for name, vs := range p.flagValues {
 		fA := p.Flag(name)
 
-		// no need to log an error since this would have been noticed during the scan
+		// no need to log an error since this would have been noticed during the
+		// scan
 		if fA == nil {
 			log.Warn("No such flag argument to parse", zap.String("name", name), zap.Strings("values", vs))
 
@@ -922,7 +934,8 @@ func (p *Parser) updateState(a Arg, state error) {
 	p.argState[a.argName()] = state
 }
 
-// Complete attaches arguments and flags to the completion Command for autocompletion support.
+// Complete attaches arguments and flags to the completion Command for
+// autocompletion support.
 func (p *Parser) Complete(cmd *complete.Command) {
 	var argPredictions []complete.Predictor
 

--- a/parser.go
+++ b/parser.go
@@ -170,6 +170,9 @@ type Parser struct {
 	// the program
 	SuppressValidation bool
 
+	// AllowEmptyArgs prevents os.Args from being used when no arguments are supplied to Parse
+	AllowEmptyArgs bool
+
 	Stdin  FileReader
 	Stdout FileWriter
 	Stderr FileWriter
@@ -285,7 +288,7 @@ func (p *Parser) Parse(argv ...string) {
 		zap.Int("shift", p.Shift),
 		zap.Strings("input", argv))
 
-	if len(argv) == 0 {
+	if len(argv) == 0 && !p.AllowEmptyArgs {
 		log.Debug("Using os.Args", zap.Strings("input", os.Args))
 		argv = os.Args[1+p.Shift:]
 	} else if len(argv) <= p.Shift && len(argv) > 0 {

--- a/pipe.go
+++ b/pipe.go
@@ -241,6 +241,7 @@ func (p *PipeArg[T]) updateValue(_ ...string) error {
 			}
 		}
 		p.data = fullData
+		log.Debug("Read Pipe argument data.", zap.String("data", string(p.data)))
 	}
 
 	dat := bytes.NewReader(fullData)
@@ -251,6 +252,7 @@ func (p *PipeArg[T]) updateValue(_ ...string) error {
 		return err
 	}
 
+	log.Debug("Updating Pipe argument value.", zap.Strings("values", inputs))
 	if err := p.v.Update(inputs...); err != nil {
 		return err
 	} else {

--- a/pipe.go
+++ b/pipe.go
@@ -84,6 +84,7 @@ func (_ Pipe) argName() argName {
 // PipeArg represents *the* (there can only be a single PipeArg defined per Parser) command-line inpu provided from the
 // Stdout of another program.
 type PipeArg[T any] struct {
+	// TODO: refactor to use *argCore.
 	piper Piper
 	input FileReader
 	md    *Metadata

--- a/pipe.go
+++ b/pipe.go
@@ -12,12 +12,14 @@ import (
 	"strings"
 )
 
-// NewLinePipe is a constructor for a PipeArg which reads new lines from a pipe supplied via the command-line.
+// NewLinePipe is a constructor for a PipeArg which reads new lines from a pipe
+// supplied via the command-line.
 func NewLinePipe[T any](variable *T, parser parse.Parser[T], options ...Option) *PipeArg[T] {
 	return NewPipeArg[T](variable, parser, &SeparatedValuePiper{Separator: "\n"}, os.Stdin, options...)
 }
 
-// CSVPipe is a constructor for a PipeArg which reads comma-separated values from a pipe supplied via the command-line.
+// CSVPipe is a constructor for a PipeArg which reads comma-separated values
+// from a pipe supplied via the command-line.
 func CSVPipe[T any](variable *T, parser parse.Parser[T], options ...Option) *PipeArg[T] {
 	return NewPipeArg[T](variable, parser, &SeparatedValuePiper{Separator: ","}, os.Stdin, options...)
 }
@@ -57,10 +59,12 @@ func PipeUsingVariable[T any](piper Piper, input FileReader, v Variable[T], opti
 type IPipe interface {
 	Arg
 
-	// PipeInput returns the FileReader wrapping the underlying input for the pipe - this is usually os.input
+	// PipeInput returns the FileReader wrapping the underlying input for the
+	// pipe - this is usually os.input
 	PipeInput() FileReader
 
-	// PipeDecode decodes the contents of the pipe into string arguments to be parsed later
+	// PipeDecode decodes the contents of the pipe into string arguments to be
+	// parsed later
 	PipeDecode(io.Reader) ([]string, error)
 
 	updateInput(r FileReader)
@@ -81,8 +85,8 @@ func (_ Pipe) argName() argName {
 	return PipeType.getIdentifier(PipeName)
 }
 
-// PipeArg represents *the* (there can only be a single PipeArg defined per Parser) command-line inpu provided from the
-// Stdout of another program.
+// PipeArg represents *the* (there can only be a single PipeArg defined per
+// Parser) command-line inpu provided from the Stdout of another program.
 type PipeArg[T any] struct {
 	// TODO: refactor to use *argCore.
 	piper Piper
@@ -149,7 +153,8 @@ func (p *PipeArg[T]) IsParsed() bool {
 	return p.parsed
 }
 
-// IsSupplied checks if a pipe has been supplied & data has been written to the pipe.
+// IsSupplied checks if a pipe has been supplied & data has been written to the
+// pipe.
 func (p *PipeArg[T]) IsSupplied() (cond bool) {
 	if p.supplied != nil {
 		return *p.supplied
@@ -255,7 +260,8 @@ func (p *PipeArg[T]) updateValue(_ ...string) error {
 	return nil
 }
 
-// A Piper is responsible for decoding the data from a pipe into raw command-line arguments
+// A Piper is responsible for decoding the data from a pipe into raw
+// command-line arguments
 type Piper interface {
 	Pipe(in io.Reader) ([]string, error)
 }

--- a/pkg/parse/types.go
+++ b/pkg/parse/types.go
@@ -47,6 +47,18 @@ func (_ Strings) Parse(input ...string) ([]string, error) {
 	return input, nil
 }
 
+type CSVStrings struct{}
+
+func (_ CSVStrings) Parse(input ...string) ([]string, error) {
+	var output []string
+
+	for _, i := range input {
+		output = append(output, strings.Split(i, ",")...)
+	}
+
+	return output, nil
+}
+
 // Int is a Parser[int].
 type Int struct{}
 

--- a/pkg/parse/types.go
+++ b/pkg/parse/types.go
@@ -2,15 +2,18 @@ package parse
 
 import (
 	"errors"
+	"fmt"
 	"github.com/hashicorp/go-multierror"
 	"os"
 	"strconv"
+	"strings"
 )
 
 var (
 	ErrEmptyInput = errors.New("no input to parse")
 )
 
+// Bool is a Parser[bool].
 type Bool struct{}
 
 func (_ Bool) Parse(input ...string) (bool, error) {
@@ -18,9 +21,16 @@ func (_ Bool) Parse(input ...string) (bool, error) {
 		return false, nil
 	}
 
-	return strconv.ParseBool(input[0])
+	b, err := strconv.ParseBool(input[0])
+
+	if err != nil {
+		err = fmt.Errorf("unable to parse bool from: %s", input[0])
+	}
+
+	return b, err
 }
 
+// String is a Parser[string].
 type String struct{}
 
 func (_ String) Parse(input ...string) (string, error) {
@@ -30,12 +40,14 @@ func (_ String) Parse(input ...string) (string, error) {
 	return input[0], nil
 }
 
+// Strings is a Parser[[]string].
 type Strings struct{}
 
 func (_ Strings) Parse(input ...string) ([]string, error) {
 	return input, nil
 }
 
+// Int is a Parser[int].
 type Int struct{}
 
 func (_ Int) Parse(in ...string) (int, error) {
@@ -46,12 +58,13 @@ func (_ Int) Parse(in ...string) (int, error) {
 	i64, err := strconv.ParseInt(in[0], 10, 64)
 
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("unable to parse integer from: %s", in[0])
 	}
 
 	return int(i64), nil
 }
 
+// Ints is a Parser[[]int].
 type Ints struct{}
 
 func (_ Ints) Parse(input ...string) ([]int, error) {
@@ -72,6 +85,7 @@ func (_ Ints) Parse(input ...string) ([]int, error) {
 	return out, res.ErrorOrNil()
 }
 
+// Float64 is a Parser[float64]
 type Float64 struct{}
 
 func (_ Float64) Parse(input ...string) (float64, error) {
@@ -79,21 +93,37 @@ func (_ Float64) Parse(input ...string) (float64, error) {
 		return 0, ErrEmptyInput
 	}
 
-	return strconv.ParseFloat(input[0], 64)
+	if f, err := strconv.ParseFloat(input[0], 64); err != nil {
+		return f, fmt.Errorf("unable to pase float64 from: %s", input[0])
+	} else {
+		return f, nil
+	}
+
 }
 
-// C is a special 'counter' type that tracks the number of times a particular argument is supplied, expecting no value to
-// be supplied - like a boolean flag.
+// C represents a 'counter' type.
+//
+// It is similar to a bool and an I - it does not expect a value to be supplied
+// with the input. Its value is the number of times the input is detected.
+//
+// It can be parsed using a Counter.
 type C int
 
 // Counter is a parser for some C - it tracks how many times the argument was supplied rather than the value supplied.
+
+// Counter is a Parser[C].
 type Counter struct{}
 
 func (_ Counter) Parse(input ...string) (C, error) {
 	return C(len(input)), nil
 }
 
-// I is a special 'indicator' that acts as a boolean switch that can be supplied multiple times.
+// I represents an 'indicator' type.
+//
+// It is similar to a bool and a C - it does not expect a value to be supplied
+// with the input. Each time the input is detected, its value is flipped.
+//
+// It can be parsed using an Indicator.
 type I bool
 
 // Indicator is a parser for some I - it flips the value for each time the input is supplied/detected.
@@ -110,14 +140,20 @@ func (i Indicator) Parse(input ...string) (I, error) {
 	return I(!active), nil
 }
 
+// File is a Parser[*os.File].
+//
+// It expects to be passed a filename, and it will attempt to create and return
+// a file handle when parsed.
 type File struct {
+	// (Optional) the permissions to open the file with
 	Mode *os.FileMode
+	// The mode of operation
 	Flag *int
 }
 
 func (f File) Parse(input ...string) (*os.File, error) {
 	if len(input) == 0 {
-		return nil, errors.New("missing filepath")
+		return nil, errors.New("unable to parse file: missing filepath")
 	}
 
 	var (
@@ -139,3 +175,57 @@ func (f File) Parse(input ...string) (*os.File, error) {
 
 	return os.OpenFile(input[0], mode, perm)
 }
+
+// Map is a Parser[map[K]V].
+type Map[K comparable, V any] struct {
+	KeyParser   Parser[K]
+	ValueParser Parser[V]
+}
+
+func (m Map[K, V]) Parse(input ...string) (map[K]V, error) {
+
+	out := map[K]V{}
+
+	for _, i := range input {
+		parts := strings.SplitN(i, "=", 2)
+
+		if len(parts) != 2 {
+			return out, fmt.Errorf("invalid syntax: expected <key>=<value>: %s", i)
+		}
+
+		key, keyErr := m.KeyParser.Parse(parts[0])
+
+		if keyErr != nil {
+			return out, fmt.Errorf("unable to parse key: %w", keyErr)
+		}
+
+		val, valErr := m.ValueParser.Parse(parts[1])
+
+		if valErr != nil {
+			return out, fmt.Errorf("unable to parse value for key %v: %w", key, valErr)
+		}
+
+		out[key] = val
+	}
+	return out, nil
+}
+
+// StringMap is a Parser[string, V].
+type StringMap[V any] Map[string, V]
+
+func (s StringMap[V]) Parse(input ...string) (map[string]V, error) {
+	return Map[string, V](s).Parse(input...)
+}
+
+var (
+	_ Parser[map[int]any]    = Map[int, any]{}
+	_ Parser[map[string]any] = StringMap[any]{}
+
+	_ Parser[C]        = Counter{}
+	_ Parser[I]        = Indicator{}
+	_ Parser[int]      = Int{}
+	_ Parser[bool]     = Bool{}
+	_ Parser[float64]  = Float64{}
+	_ Parser[string]   = String{}
+	_ Parser[[]string] = Strings{}
+)

--- a/position.go
+++ b/position.go
@@ -9,8 +9,8 @@ import (
 type IPositional interface {
 	Arg
 
-	// Index returns the index (position) of the PositionalArg (or the starting index of the remaining args if
-	// ArgRemaining is true)
+	// Index returns the index (position) of the PositionalArg (or the starting
+	// index of the remaining args if ArgRemaining is true)
 	Index() int
 
 	isPositionalArg()
@@ -21,7 +21,8 @@ func NewPosition[T any](variable *T, index int, parser parse.Parser[T], opts ...
 	return PositionUsingVariable[T](index, NewVariable[T](variable, parser), opts...)
 }
 
-// NewPositions is a constructor for a number of positional arguments starting from some index.
+// NewPositions is a constructor for a number of positional arguments starting
+// from some index.
 func NewPositions[T any](variables *[]T, fromIndex int, parser parse.Parser[T], opts ...Option) *PositionalArg[[]T] {
 	return PositionsUsingVariable[T](fromIndex, NewVariable[[]T](variables, parse.Slice[T](parser)), opts...)
 }
@@ -69,7 +70,8 @@ var positionOptions = []Option{
 	withDefaultDisabled(),
 }
 
-// A PositionalArg represents a particular index (or indexes) of positional arguments representing some type T.
+// A PositionalArg represents a particular index (or indexes) of positional
+// arguments representing some type T.
 //
 // Should be created by the NewPosition and NewPositions functions.
 type PositionalArg[T any] struct {

--- a/set.go
+++ b/set.go
@@ -103,7 +103,8 @@ func (s *Set) Get(id Identifier) Arg {
 	return nil
 }
 
-// ByShorthand returns the Arg for the given shorthand identifier, if it exists, otherwise nil.
+// ByShorthand returns the Arg for the given shorthand identifier, if it exists,
+// otherwise nil.
 func (s *Set) ByShorthand(sh string) Arg {
 	if sh == "" {
 		return nil
@@ -122,7 +123,8 @@ func (s *Set) ByShorthand(sh string) Arg {
 	return s.Get(id)
 }
 
-// Flag returns the flag for the given Id/identifier, if it exists, otherwise nil.
+// Flag returns the flag for the given Id/identifier, if it exists, otherwise
+// nil.
 func (s *Set) Flag(name string) IFlag {
 	if f, exists := s.flags[name]; exists {
 		return f
@@ -170,7 +172,8 @@ func (s *Set) AddFlag(f IFlag, opts ...Option) error {
 	return nil
 }
 
-// Key returns the key-value argument for the given Id/identifier, if it exists, otherwise nil.
+// Key returns the key-value argument for the given Id/identifier, if it exists,
+// otherwise nil.
 func (s *Set) Key(name string) IKeyValue {
 	if f, exists := s.keys[name]; exists {
 		return f
@@ -217,7 +220,8 @@ func (s *Set) AddKeyValue(kv IKeyValue, opts ...Option) error {
 	return nil
 }
 
-// Pos returns the positional argument at the supplied index, if it exists, otherwise nil.
+// Pos returns the positional argument at the supplied index, if it exists,
+// otherwise nil.
 func (s *Set) Pos(index int) IPositional { // nolint: ireturn
 	k, exists := s.posArgs[index]
 
@@ -228,7 +232,8 @@ func (s *Set) Pos(index int) IPositional { // nolint: ireturn
 	return s.positions.Get(k)
 }
 
-// PosS is a wrapper around Pos which accepts a string representation of the integer position.
+// PosS is a wrapper around Pos which accepts a string representation of the
+// integer position.
 func (s *Set) PosS(sindex string) IPositional {
 	i, _ := strconv.ParseInt(sindex, 10, 64)
 
@@ -242,7 +247,8 @@ func (s *Set) Positions() []IPositional {
 
 // AddPosition adds a positional argument to the Set.
 //
-// The Set expects positional arguments to be supplied in order and returns a wrapped ErrInvalidIndex if arguments
+// The Set expects positional arguments to be supplied in order and returns a
+// wrapped ErrInvalidIndex if arguments
 // are specified in an invalid order.
 func (s *Set) AddPosition(a IPositional, opts ...Option) error {
 	index := a.Index()
@@ -303,7 +309,8 @@ func (s *Set) AddPipe(p IPipe, opts ...Option) error {
 	return nil
 }
 
-// argMap is a collection of Arg implementations (of the same Type), indexed by their Id
+// argMap is a collection of Arg implementations (of the same Type), indexed by
+// their Id.
 type argMap[A Arg] map[string]A
 
 // List returns all the Arg(s) within the collection.

--- a/variable.go
+++ b/variable.go
@@ -6,9 +6,11 @@ import (
 	"os"
 )
 
-// FileWriter represents some type of file-like object that would be used as an output we can write to.
+// FileWriter represents some type of file-like object that would be used as an
+// output we can write to.
 //
-// Usually, in this package, values of this type will be set to os.Stdout by default.
+// Usually, in this package, values of this type will be set to os.Stdout by
+// default.
 type FileWriter interface {
 	io.Writer
 	Stat() (os.FileInfo, error)
@@ -17,20 +19,25 @@ type FileWriter interface {
 
 type FileInfo = os.FileInfo
 
-// FileReader represents some time of file-like object that would be used as an input we can read from.
+// FileReader represents some time of file-like object that would be used as an
+// input we can read from.
 //
-// Usually, in this package, values of this type will be set to os.Stdin by default
+// Usually, in this package, values of this type will be set to os.Stdin by
+// default.
 type FileReader interface {
 	io.Reader
 	Stat() (os.FileInfo, error)
 	Fd() uintptr
 }
 
-// A Variable refers to some program variable that can be parsed from string input.
+// A Variable refers to some program variable that can be parsed from string
+// input.
 //
-// Internally, a Variable uses a Func to parse some string input into the underlying variable.
+// Internally, a Variable uses a Func to parse some string input into the
+// underlying variable.
 type Variable[T any] interface {
-	// Update parses the given input and attempts to update the underlying variable
+	// Update parses the given input and attempts to update the underlying
+	// variable
 	Update(...string) error
 	// Ref returns a reference to the underlying variable
 	Ref() *T
@@ -40,11 +47,14 @@ type Variable[T any] interface {
 	Parser() parse.Parser[T]
 }
 
-// NewVariables is a constructor for a Variable that has an underlying argumentVariable of slice-type.
+// NewVariables is a constructor for a Variable that has an underlying variable
+// of slice-type.
 //
-// This is a helper function which converts the supplied Func into one that supports slices via Slice.
+// This is a helper function which converts the supplied Func into one that
+// supports slices via Slice.
 //
-// A specific Func can be used by creating a Variable using NewVariablesWithParser.
+// A specific Func can be used by creating a Variable using
+// NewVariablesWithParser.
 func NewVariables[T any](variables *[]T, p parse.Parser[T]) Variable[[]T] {
 	if variables == nil {
 		var anon []T
@@ -56,7 +66,8 @@ func NewVariables[T any](variables *[]T, p parse.Parser[T]) Variable[[]T] {
 	}
 }
 
-// NewVariablesWithParser is a constructor for a Variable that has an underlying Func of slice-type.
+// NewVariablesWithParser is a constructor for a Variable that has an underlying
+// Func of slice-type.
 func NewVariablesWithParser[T any](variables *[]T, p parse.Parser[[]T]) Variable[[]T] {
 	return &argumentVariable[[]T]{
 		v: variables,
@@ -75,10 +86,11 @@ func NewVariable[T any](variable *T, p parse.Parser[T]) Variable[T] {
 	}
 }
 
-// argumentVariable wraps some variable of type T and is responsible for updating the underlying value of this variable
-// when required.
+// argumentVariable wraps some variable of type T and is responsible for
+// updating the underlying value of this variable when required.
 //
-// The Parser is responsible for the generating the new value (from string inpu) to be held by the variable.
+// The Parser is responsible for the generating the new value (from string
+// input) to be held by the variable.
 type argumentVariable[T any] struct {
 	v *T              // v is the underlying go-variable being maintained by the argumentVariable
 	p parse.Parser[T] // p is the Parser responsible for creating a new value for the go-variable


### PR DESCRIPTION
Created the `argCore` type - responsible for holding a `Variable[T]` and `*Metadata` for some argument.

It handles everything but how to identify the argument - this is still handled by each implementation.